### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Archive Runtimes
         run: |
-          for dir in install/ ; do
-            tar -czvf install/$dir-${{ steps.get_version.outputs.version-without-v }}.tar.gz -C $dir .
+          cd install
+          for dir in install/*/ ; do
+            runtime=$(basename $dir)
+            tar -czvf install/$runtime-${{ steps.get_version.outputs.version-without-v }}.tar.gz -C install $runtime
           done
 
       # This uses gh release upload instead of actions/upload-release-asset

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd install
-          for f in $(find . -name '*.tar.gz'); do
+          for f in *.tar.gz'; do
             gh release upload ${{ steps.get_version.outputs.version }} $f
           done
 


### PR DESCRIPTION
Alire requires the archive to contain a single directory which in turn contains the sources.