### PR TITLE
Update GPR file instructions to change runtime_build -> ravenscar_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,28 @@ Using the light_tasking_nrf52840 as an example, first edit your
    light_tasking_nrf52840 = "*"
    ```
 
-Then edit your project file to add the following elements:
- - "with" the run-time project file:
-   ```ada
-   with "runtime_build.gpr";
-   ```
- - specify the `Target` and `Runtime` attributes:
-   ```ada
-   for Target use runtime_build'Target;
-   for Runtime ("Ada") use runtime_build'Runtime ("Ada");
-   ```
+Then edit your project file to add the following elements, depending on your
+chosen runtime profile:
+ - when using the **light** runtime profile:
+   - "with" the run-time project file:
+     ```ada
+     with "runtime_build.gpr";
+     ```
+   - specify the `Target` and `Runtime` attributes:
+     ```ada
+     for Target use runtime_build'Target;
+     for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+     ```
+ - when using the **light-tasking** or **embedded** runtime profile:
+   - "with" the run-time project file:
+     ```ada
+     with "ravenscar_build.gpr";
+     ```
+   - specify the `Target` and `Runtime` attributes:
+     ```ada
+     for Target use ravenscar_build'Target;
+     for Runtime ("Ada") use ravenscar_build'Runtime ("Ada");
+     ```
 
 ## Resources Used
 

--- a/crateify.py
+++ b/crateify.py
@@ -181,6 +181,7 @@ def main():
         "pretty_target": pretty_target,
         "project_files_list": str(project_files),
         "version": args.version,
+        "runtime_proj_prefix": "ravenscar" if has_libgnarl else "runtime",
     }
 
     templates_dir = pathlib.Path(__file__).parent / "templates"

--- a/templates/alire.toml.in
+++ b/templates/alire.toml.in
@@ -15,12 +15,12 @@ First edit your `alire.toml` file and add the following elements:
 Then edit your project file to add the following elements:
  - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
    ```ada
-   with "runtime_build.gpr";
+   with "$(runtime_proj_prefix)_build.gpr";
    ```
  - Specify the `Target` and `Runtime` attributes:
    ```ada
-      for Target use runtime_build'Target;
-      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+      for Target use $(runtime_proj_prefix)_build'Target;
+      for Runtime ("Ada") use $(runtime_proj_prefix)_build'Runtime ("Ada");
    ```
 """
 


### PR DESCRIPTION
The current instructions tell the user to "with" runtime_build.gpr only in their project file. For light-tasking/embedded runtimes Alire normally auto-withs ravenscar_build.gpr in the auto-generated config file. But if the user doesn't "with" that config in their main project file, or if Alire is configured with auto-with-gpr=false then ravenscar_build.gpr will not get built, leading to errors when building complaining that ali files for libgnarl units don't exist.

These new instructions tell the user to with ravenscar_build.gpr in their project file. Since ravenscar_build.gpr withs runtime_build.gpr this will ensure that both libgnat and libgnarl are compiled properly.